### PR TITLE
Added precreated desktop run configuration

### DIFF
--- a/.run/desktop.run.xml
+++ b/.run/desktop.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="desktop" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":desktop:run" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
- Added precreated desktop run configuration. With this its become possible to switch android -> desktop run configuration and run project to engage build and run desktop kmm app sequence. No need to search for and run main function

![image](https://user-images.githubusercontent.com/55731252/212685616-f4632caf-9b21-4f1b-ba84-e19547ca7798.png)
